### PR TITLE
Fixes applied to e-hentai/exhentai and hentaihaven.red

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,8 @@ on:
   push:
     tags-ignore:
       - '*.*' # We don't want this to run on release
+    branches:
+      - '*.*'
 jobs:
 
   build:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,8 @@
 name: Go
-on: [push]
+on:
+  push:
+    tags-ignore:
+      - '*.*' # We don't want this to run on release
 jobs:
 
   build:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,10 +1,5 @@
 name: Go
-on:
-  push:
-    tags-ignore:
-      - '*.*' # We don't want this to run on release
-    branches:
-      - '*.*'
+on: [push]
 jobs:
 
   build:

--- a/extractor/booru/booru.go
+++ b/extractor/booru/booru.go
@@ -53,7 +53,7 @@ func Extract(url string) ([]static.Data, error) {
 // ParseURL for danbooru pages
 func ParseURL(url string) (string, error) {
 	if !strings.Contains(url, "%20") {
-		re := regexp.MustCompile("https://booru\\.io/p/(.+)")
+		re := regexp.MustCompile(`https://booru\.io/p/(.+)`)
 		matchedID := re.FindStringSubmatch(url)
 		if len(matchedID) > 2 {
 			return "", errors.New("Invalid URL")
@@ -147,7 +147,7 @@ func extractData(queryURL string) ([]static.Data, error) {
 
 // GetBestQualityImg of transformation
 func GetBestQualityImg(transformations map[string]string) (string, string) {
-	re := regexp.MustCompile("[0-9]+")
+	re := regexp.MustCompile(`[0-9]+`)
 	transformationType := ""
 	transformationValue := ""
 	currentBest := 0

--- a/extractor/danbooru/danbooru.go
+++ b/extractor/danbooru/danbooru.go
@@ -34,12 +34,12 @@ func Extract(url string) ([]static.Data, error) {
 
 // ParseURL for danbooru pages
 func ParseURL(url string) ([]string, error) {
-	re := regexp.MustCompile("page=([0-9]+)")
+	re := regexp.MustCompile(`page=([0-9]+)`)
 	pageNo := re.FindAllString(url, -1)
 	// pageNo = url?page=number -> if it's there it means overview page otherwise single post or invalid
 	if len(pageNo) == 0 {
 
-		re := regexp.MustCompile("/posts/[0-9]+")
+		re := regexp.MustCompile(`/posts/[0-9]+`)
 		linkToPost := re.FindString(url)
 		if linkToPost == "" {
 			return nil, errors.New("[Danbooru]Invalid Url no post found")
@@ -53,7 +53,7 @@ func ParseURL(url string) ([]string, error) {
 		return nil, err
 	}
 
-	re = regexp.MustCompile("data-id=\"([^\"]+)")
+	re = regexp.MustCompile(`data-id="([^"]+)`)
 	matchedIDs := re.FindAllStringSubmatch(htmlString, -1)
 
 	out := []string{}
@@ -70,7 +70,7 @@ func extractData(postURL string) (static.Data, error) {
 		return static.Data{}, err
 	}
 
-	re := regexp.MustCompile("data-width=\"([^\"]+)\"[ ]+data-height=\"([^\"]+)\".+alt=\"([^\"]+)\".+src=\"([^\"]+)\"")
+	re := regexp.MustCompile(`data-width="([^"]+)"[ ]+data-height="([^"]+)".+alt="([^"]+)".+src="([^"]+)"`)
 	matchedImgData := re.FindStringSubmatch(htmlString)
 	if len(matchedImgData) != 5 {
 		return static.Data{}, errors.New("[Danbooru] Image parsing failed")

--- a/extractor/ehentai/ehentai.go
+++ b/extractor/ehentai/ehentai.go
@@ -44,7 +44,7 @@ func ParseURL(URL string) []string {
 		return []string{}
 	}
 
-	re := regexp.MustCompile("https://e-hentai.org/g/[^\"]+")
+	re := regexp.MustCompile(`https://e-hentai.org/g/[^"]+`)
 	galleries := re.FindAllStringSubmatch(htmlString, -1)
 	if len(galleries) == 0 {
 		return []string{}
@@ -73,7 +73,7 @@ func extractData(URL string) ([]static.Data, error) {
 		return extractData(URL + "?nw=session")
 	}
 
-	re := regexp.MustCompile("([0-9]+) pages")
+	re := regexp.MustCompile(`([0-9]+) pages`)
 	htmlNumberOfPages := re.FindStringSubmatch(htmlString)
 	if len(htmlNumberOfPages) != 2 {
 		return nil, errors.New("[E-Hentai] error while trying to access the gallery images")
@@ -83,7 +83,7 @@ func extractData(URL string) ([]static.Data, error) {
 		return nil, errors.New("[E-Hentai] couldn't get number of pages")
 	}
 
-	re = regexp.MustCompile("https://e-hentai.org/s[^\"]+-[0-9]+")
+	re = regexp.MustCompile(`https://e-hentai.org/s[^"]+-[0-9]+`)
 	imgURLs := re.FindAllString(htmlString, -1)
 
 	// if gallery has more than 40 images -> walk other pages for links aswell
@@ -102,13 +102,12 @@ func extractData(URL string) ([]static.Data, error) {
 			return nil, errors.New("[E-Hentai] unvaild image URL")
 		}
 
-		re := regexp.MustCompile("<h1>([^<]+)")
-		matchedTitle := re.FindAllStringSubmatch(htmlString, -1)
-		if len(matchedTitle) == 0 {
+		title := utils.GetH1(&htmlString, 0)
+		if title == "" {
 			return nil, errors.New("[E-Hentai] unvaild image title")
 		}
 
-		re = regexp.MustCompile(`<div>[^.]+\.([^::]+):: ([^::]+) :: ([^.]+.[0-9]+) ([A-Z]{2})`)
+		re := regexp.MustCompile(`<div>[^.]+\.([^::]+):: ([^::]+) :: ([^.]+.[0-9]+) ([A-Z]{2})`)
 		matchedFileInfo := re.FindAllStringSubmatch(htmlString, -1)
 		if len(matchedFileInfo) == 0 {
 			return nil, errors.New("[E-Hentai] unvaild image file info")
@@ -116,7 +115,7 @@ func extractData(URL string) ([]static.Data, error) {
 		fileInfo := matchedFileInfo[0]
 
 		// sometimes the "full image url is not provided"
-		re = regexp.MustCompile("<img id=\"img\" src=\"([^\"]+)")
+		re = regexp.MustCompile(`<img id="img" src="([^"]+)`)
 		matchedSrcURL := re.FindAllStringSubmatch(htmlString, -1)
 		if len(matchedSrcURL) != 1 {
 			return nil, errors.New("[E-Hentai] unvaild image src")
@@ -127,7 +126,7 @@ func extractData(URL string) ([]static.Data, error) {
 
 		data = append(data, static.Data{
 			Site:  site,
-			Title: fmt.Sprintf("%s - %d", matchedTitle[0][1], idx),
+			Title: fmt.Sprintf("%s - %d", title, idx),
 			Type:  "image",
 			Streams: map[string]static.Stream{
 				"0": {

--- a/extractor/exhentai/exhentai.go
+++ b/extractor/exhentai/exhentai.go
@@ -183,6 +183,7 @@ func (ex *extractor) extractData(URLs []string) ([]static.Data, error) {
 			}
 			srcURL = []string{matchedSrcURL[0][1]}
 		}
+		fmt.Println(srcURL[0])
 
 		// size will be empty if err occurs
 		fSize, _ := strconv.ParseFloat(fileInfo[3], 64)

--- a/extractor/exhentai/exhentai.go
+++ b/extractor/exhentai/exhentai.go
@@ -159,25 +159,24 @@ func (ex *extractor) extractData(URLs []string) ([]static.Data, error) {
 			return nil, err
 		}
 
-		re := regexp.MustCompile("<h1>([^<]+)")
-		matchedTitle := re.FindAllStringSubmatch(htmlString, -1)
-		if len(matchedTitle) == 0 {
+		title := utils.GetH1(&htmlString, 0)
+		if len(title) == 0 {
 			return nil, errors.New("[ExHentai] invaild image title")
 		}
 
-		re = regexp.MustCompile(`<div>[^.]+\.([^::]+):: ([^::]+) :: ([^.]+.[0-9]+) ([A-Z]{2})`)
+		re := regexp.MustCompile(`<div>[^.]+\.([^::]+):: ([^::]+) :: ([^.]+.[0-9]+) ([A-Z]{2})`)
 		matchedFileInfo := re.FindAllStringSubmatch(htmlString, -1)
 		if len(matchedFileInfo) == 0 {
 			return nil, errors.New("[ExHentai] invaild image file info")
 		}
 		fileInfo := matchedFileInfo[0]
 
-		re = regexp.MustCompile("https://exhentai.org/fullimg[^\"]+")
+		re = regexp.MustCompile(`https://exhentai.org/fullimg[^"]+`)
 		srcURL := re.FindStringSubmatch(htmlString)
 		if len(srcURL) != 1 {
 
 			// sometimes the "full image url is not provided"
-			re = regexp.MustCompile("<img id=\"img\" src=\"([^\"]+)")
+			re = regexp.MustCompile(`<img id="img" src="([^"]+)`)
 			matchedSrcURL := re.FindAllStringSubmatch(htmlString, -1)
 			if len(matchedSrcURL) != 1 {
 				return nil, errors.New("[ExHentai] invaild image src")
@@ -208,7 +207,7 @@ func (ex *extractor) extractData(URLs []string) ([]static.Data, error) {
 
 		data = append(data, static.Data{
 			Site:  site,
-			Title: fmt.Sprintf("%s - %d", matchedTitle[0][1], idx+1),
+			Title: fmt.Sprintf("%s - %d", title, idx+1),
 			Type:  "image",
 			Streams: map[string]static.Stream{
 				"0": {
@@ -276,7 +275,7 @@ func Extract(URL string) ([]static.Data, error) {
 			return nil, errors.New("[ExHentai] invaild URL")
 		}
 
-		re := regexp.MustCompile("([0-9]+) pages")
+		re := regexp.MustCompile(`([0-9]+) pages`)
 		htmlNumberOfPages := re.FindStringSubmatch(htmlString)
 		if len(htmlNumberOfPages) != 2 {
 			return nil, errors.New("[ExHentai] error while trying to access the gallery images")

--- a/extractor/hentaihaven/hentaihaven.go
+++ b/extractor/hentaihaven/hentaihaven.go
@@ -88,7 +88,7 @@ func extractData(URL string) (static.Data, error) {
 	if err != nil {
 		return static.Data{}, err
 	}
-	title := strings.Trim(utils.GetH1(&htmlString), " \n\t")
+	title := strings.Trim(utils.GetH1(&htmlString, -1), " \n\t")
 
 	re := regexp.MustCompile(`[^"]*/player/[^"]*`)
 	playerURL := re.FindString(htmlString) // 1=id  2=nonce

--- a/extractor/hentais/hentais.go
+++ b/extractor/hentais/hentais.go
@@ -59,7 +59,7 @@ func extractData(URL string) (static.Data, error) {
 		return static.Data{}, err
 	}
 
-	title := utils.GetH1(&htmlString)
+	title := utils.GetH1(&htmlString, -1)
 
 	re := regexp.MustCompile(`player.php[^']*`)
 	playerURL := site + re.FindString(htmlString)

--- a/extractor/hentaistream/hentaistream.go
+++ b/extractor/hentaistream/hentaistream.go
@@ -105,7 +105,7 @@ func extractData(URL string) (static.Data, error) {
 
 	if strings.Contains(htmlString, "<title>DDOS-GUARD</title>") {
 		time.Sleep(200 * time.Millisecond)
-		htmlString, err = request.Get(URL)
+		htmlString, _ = request.Get(URL)
 	}
 
 	re := regexp.MustCompile(`<iframe[\s\S]*?(player[^#]*)#([^"]*)`)
@@ -141,7 +141,7 @@ func extractData(URL string) (static.Data, error) {
 
 	return static.Data{
 		Site:    site,
-		Title:   utils.GetH1(&htmlString),
+		Title:   utils.GetH1(&htmlString, -1),
 		Type:    "video",
 		Streams: streams,
 		Url:     URL,

--- a/extractor/hentaiworld/hentaiworld.go
+++ b/extractor/hentaiworld/hentaiworld.go
@@ -27,10 +27,10 @@ func Extract(url string) ([]static.Data, error) {
 
 // ParseURL for data extraction
 func ParseURL(url string) ([]string, error) {
-	re := regexp.MustCompile("(?:https://hentaiworld.tv/)(?:all-episodes|uncensored|3d|hentai-videos/category|hentai-videos/tag)/")
+	re := regexp.MustCompile(`(?:https://hentaiworld.tv/)(?:all-episodes|uncensored|3d|hentai-videos/category|hentai-videos/tag)/`)
 	validMassURL := re.FindString(url)
 	if validMassURL == "" {
-		re := regexp.MustCompile("hentai-videos/(?:3d/)?(?:.+episode-[0-9]*)?")
+		re := regexp.MustCompile(`hentai-videos/(?:3d/)?(?:.+episode-[0-9]*)?`)
 		validEpisodeURL := re.FindString(url)
 		if validEpisodeURL != "" {
 			return []string{url}, nil
@@ -43,7 +43,7 @@ func ParseURL(url string) ([]string, error) {
 		return []string{}, fmt.Errorf("[HentaiWorld]HTTP GET URL  error %v", err)
 	}
 
-	re = regexp.MustCompile("\"display-all-posts-background\"><a href=\"([^\"]*)")
+	re = regexp.MustCompile(`"display-all-posts-background"><a href="([^"]*)`)
 	matchedEpisodesURLs := re.FindAllStringSubmatch(massHTMLPage, -1)
 	urls := []string{}
 	for _, matchedURL := range matchedEpisodesURLs {
@@ -64,18 +64,17 @@ func ExtractData(url string) static.Data {
 		return static.Data{Err: err}
 	}
 
-	re := regexp.MustCompile("<h1[^>]*>([^<]*)")
-	title := strings.TrimSpace(utils.GetLastItemString(re.FindStringSubmatch(postHTMLpage)))
+	title := strings.TrimSpace(utils.GetH1(&postHTMLpage, -1))
 
 	if strings.Contains(title, "\u0026#8211;") {
 		title = strings.ReplaceAll(title, "\u0026#8211;", "-")
 	}
 
-	re = regexp.MustCompile("window.open\\(\\'([^']+\\.([0-9a-zA-z]*))")
+	re := regexp.MustCompile(`window.open\(\'([^']+\.([0-9a-zA-z]*))`)
 	infoAboutFile := re.FindStringSubmatch(postHTMLpage) // 1 = dlURL 2=ext
 
 	if len(infoAboutFile) != 3 {
-		re = regexp.MustCompile("src='(.*)\\.(mp4*).*")
+		re = regexp.MustCompile(`src='(.*)\.(mp4*).*`)
 		infoAboutFile = re.FindStringSubmatch(postHTMLpage) // 1 = dlURL 2=ext
 		if len(infoAboutFile) != 3 {
 			return static.Data{Err: fmt.Errorf("[HentaiWorld] Get scrape video info for URL %s", url)}

--- a/extractor/hentaiworld/hentaiworld.go
+++ b/extractor/hentaiworld/hentaiworld.go
@@ -64,7 +64,7 @@ func ExtractData(url string) static.Data {
 		return static.Data{Err: err}
 	}
 
-	title := strings.TrimSpace(utils.GetH1(&postHTMLpage, -1))
+	title := strings.TrimSuffix(utils.GetMeta(&postHTMLpage, "og:title"), " - HentaiWorld")
 
 	if strings.Contains(title, "\u0026#8211;") {
 		title = strings.ReplaceAll(title, "\u0026#8211;", "-")

--- a/extractor/htstreaming/htstreaming.go
+++ b/extractor/htstreaming/htstreaming.go
@@ -66,7 +66,7 @@ func Extract(URL string) ([]static.Data, error) {
 	URLs := ParseURL(URL)
 	if len(URLs) < 1 {
 		log.Println(URL)
-		return nil, fmt.Errorf("[%s] No matching URL found.", site)
+		return nil, fmt.Errorf("[%s] No matching URL found", site)
 	}
 
 	data := []static.Data{}

--- a/extractor/htstreaming/htstreaming.go
+++ b/extractor/htstreaming/htstreaming.go
@@ -52,6 +52,10 @@ func ParseURL(URL string) []string {
 		re = regexp.MustCompile(`[^"]*red/hentai[^"]*`) //this sites URLs are built diff
 	}
 	matchedURLs := re.FindAllString(htmlString, -1)
+	if strings.HasPrefix(URL, "https://hentaihaven.red") {
+		//remove the five popular hentai on the side bar
+		matchedURLs = matchedURLs[:len(matchedURLs)-5]
+	}
 
 	return removeAdjDuplicates(matchedURLs)
 }

--- a/extractor/htstreaming/htstreaming_test.go
+++ b/extractor/htstreaming/htstreaming_test.go
@@ -75,8 +75,9 @@ func TestExtract(t *testing.T) {
 			want: 1,
 		}, {
 			name: "Overview hentaihaven.red/",
-			url:  "https://hentaihaven.red/ratings/",
-			want: 35,
+			url:  "https://hentaihaven.red/genre/2019-english/",
+			want: 9,
+			//can be more videos at the time when I am adding this it was only 9 -> normally it is 35 per site but that would be too much for testing
 		}, /*{
 			name: "Single Episode hentai.tv",
 			url:  "https://hentai.tv/hentai/chiisana-tsubomi-no-sono-oku-ni-episode-1/",

--- a/extractor/htstreaming/htstreaming_test.go
+++ b/extractor/htstreaming/htstreaming_test.go
@@ -76,8 +76,8 @@ func TestExtract(t *testing.T) {
 		}, {
 			name: "Overview hentaihaven.red/",
 			url:  "https://hentaihaven.red/genre/2019-english/",
-			want: 9,
-			//can be more videos at the time when I am adding this it was only 9 -> normally it is 35 per site but that would be too much for testing
+			want: 4,
+			//can be more videos at the time when I am adding this it was only 4 -> normally it is 30 per site but that would be too much for testing
 		}, /*{
 			name: "Single Episode hentai.tv",
 			url:  "https://hentai.tv/hentai/chiisana-tsubomi-no-sono-oku-ni-episode-1/",

--- a/extractor/imgboard/imgboard.go
+++ b/extractor/imgboard/imgboard.go
@@ -18,7 +18,7 @@ var mass bool
 // ParseURL of input
 func ParseURL(url string) []string {
 
-	re := regexp.MustCompile("(?:show/|&id=)[0-9]*")
+	re := regexp.MustCompile(`(?:show/|&id=)[0-9]*`)
 	if re.MatchString(url) {
 		return []string{url}
 	}
@@ -110,7 +110,7 @@ func ParseURL(url string) []string {
 
 // Extract post data
 func Extract(url string) ([]static.Data, error) {
-	re := regexp.MustCompile("https://[^/]*")
+	re := regexp.MustCompile(`https://[^/]*`)
 	siteURL = re.FindString(url)
 	mass = false
 
@@ -143,7 +143,7 @@ func Extract(url string) ([]static.Data, error) {
 
 func extractData(url string) (static.Data, error) {
 
-	re := regexp.MustCompile("http?s://(?:www.)?([^.]*)")
+	re := regexp.MustCompile(`http?s://(?:www.)?([^.]*)`)
 	siteName := re.FindStringSubmatch(siteURL)[1]
 
 	postHTML, err := request.Get(url)
@@ -173,10 +173,10 @@ func extractData(url string) (static.Data, error) {
 		}
 	}
 
-	re = regexp.MustCompile("Id: [^<]*")
+	re = regexp.MustCompile(`Id: [^<]*`)
 	id := re.FindString(postHTML)
 
-	re = regexp.MustCompile("Size: [^<]*")
+	re = regexp.MustCompile(`Size: [^<]*`)
 	quality := re.FindString(postHTML)
 	quality = strings.ReplaceAll(quality, "Size: ", "")
 

--- a/extractor/imgboard/imgboard_test.go
+++ b/extractor/imgboard/imgboard_test.go
@@ -166,6 +166,7 @@ func TestExtractDataFromDirectLink(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			config.Amount = 10
 			elements, err := Extract(tt.url)
 			if err != nil {
 				t.Error(err)

--- a/extractor/nhentai/nhentai.go
+++ b/extractor/nhentai/nhentai.go
@@ -77,7 +77,7 @@ func ParseURL(URL string) ([]string, string) {
 		// if there are two "int" values it means the exact page was supplied
 		var page string
 
-		re = regexp.MustCompile("[0-9]+")
+		re = regexp.MustCompile(`[\d]+`)
 		urlNumbers := re.FindAllString(URL, -1)
 		if len(urlNumbers) <= 0 {
 			return nil, ""

--- a/extractor/rule34/rule34.go
+++ b/extractor/rule34/rule34.go
@@ -46,7 +46,7 @@ func ParseURL(URL string) []string {
 		return nil
 	}
 
-	re := regexp.MustCompile("(\\S*)/[0-9]*?$")
+	re := regexp.MustCompile(`(\S*)/[0-9]*?$`)
 	baseURL := re.FindStringSubmatch(URL)[1]
 
 	content := []string{}
@@ -57,7 +57,7 @@ func ParseURL(URL string) []string {
 			return nil
 		}
 
-		re := regexp.MustCompile("data-post-id=\"([^\"]+)")
+		re := regexp.MustCompile(`data-post-id="([^"]+)`)
 		matchedPosts := re.FindAllStringSubmatch(htmlString, -1)
 		if len(matchedPosts) < 1 {
 			return content
@@ -83,16 +83,16 @@ func extractData(URL string) (static.Data, error) {
 		return static.Data{}, err
 	}
 
-	re := regexp.MustCompile("[0-9]{3,}")
+	re := regexp.MustCompile(`[0-9]{3,}`)
 	id := re.FindStringSubmatch(URL)
 
 	// get source of img
-	re = regexp.MustCompile("id='main_image' src='([^']+)")
+	re = regexp.MustCompile(`id='main_image' src='([^']+)`)
 	matchedPostSrcURL := re.FindStringSubmatch(htmlString)
 	if len(matchedPostSrcURL) != 2 {
 
 		// maybe it's a video - try to get source URL
-		re = regexp.MustCompile("<source src='([^']+)")
+		re = regexp.MustCompile(`<source src='([^']+)`)
 		matchedPostSrcURL = re.FindStringSubmatch(htmlString)
 		if len(matchedPostSrcURL) != 2 {
 			return static.Data{}, errors.New("[Rule34] src URL not found for post " + URL)
@@ -101,7 +101,7 @@ func extractData(URL string) (static.Data, error) {
 
 	postSrcURL := matchedPostSrcURL[1]
 
-	re = regexp.MustCompile("tag_edit__tags' value='([^']+)")
+	re = regexp.MustCompile(`tag_edit__tags' value='([^']+)`)
 	matchedTagBox := re.FindStringSubmatch(htmlString)
 	if len(matchedTagBox) != 2 {
 		fmt.Println(htmlString)
@@ -128,14 +128,14 @@ func extractData(URL string) (static.Data, error) {
 
 	var quality string
 	if dataType == "video" {
-		re := regexp.MustCompile("id='main_image'.+\n[^0-9]+([0-9]+)[^0-9]+([0-9]+)")
+		re := regexp.MustCompile(`id='main_image'.+\n[^0-9]+([0-9]+)[^0-9]+([0-9]+)`)
 		matchedQualityProperties := re.FindStringSubmatch(htmlString)
 		if len(matchedQualityProperties) != 3 {
 			return static.Data{}, errors.New("[Rule34] quality not found for post " + URL)
 		}
 		quality = fmt.Sprintf("%s x %s", matchedQualityProperties[1], matchedQualityProperties[2])
 	} else {
-		re := regexp.MustCompile("data-(width|height)='([0-9]+)")
+		re := regexp.MustCompile(`data-(width|height)='([0-9]+)`)
 		matchedQualityProperties := re.FindAllStringSubmatch(htmlString, -1)
 		if len(matchedQualityProperties) != 2 {
 			return static.Data{}, errors.New("[Rule34] quality not found for post " + URL)

--- a/extractor/rule34/rule34_test.go
+++ b/extractor/rule34/rule34_test.go
@@ -114,12 +114,12 @@ func TestMassExtract(t *testing.T) {
 		{
 			name: "Test mass",
 			url:  "https://rule34.paheal.net/post/list/1",
-			want: 26,
+			want: 10,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			config.Amount = 26
+			config.Amount = 10
 			elements, err := Extract(tt.url)
 			if err != nil {
 				t.Error("elements has error or is too big for single tests")

--- a/extractor/universal/universal.go
+++ b/extractor/universal/universal.go
@@ -12,7 +12,7 @@ import (
 // Extract universal link
 func Extract(url string, site string) ([]static.Data, error) {
 
-	re := regexp.MustCompile("/([^/]+)\\.([a-zA-z0-9]*)?\\??[0-9a-zA-Z&=]*$")
+	re := regexp.MustCompile(`/([^/]+)\.([a-zA-z0-9]*)?\??[0-9a-zA-Z&=]*$`)
 	// matches[1] = title, matches[2] = fileext
 	matches := re.FindStringSubmatch(url)
 	if len(matches) < 3 {

--- a/request/request.go
+++ b/request/request.go
@@ -3,7 +3,6 @@ package request
 import (
 	"crypto/tls"
 	"errors"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -169,8 +168,8 @@ func (p *Myjar) SetCookies(u *url.URL, cookies []*http.Cookie) {
 	if u.Host == "forums.e-hentai.org" {
 		u.Host = "exhentai.org"
 	}
-	fmt.Printf("The URL is : %s\n", u.String())
-	fmt.Printf("The cookie being set is : %s\n", cookies)
+	//fmt.Printf("The URL is : %s\n", u.String())
+	//fmt.Printf("The cookie being set is : %s\n", cookies)
 
 	//preserve old cookies and overwrite old ones with new cookies
 	isInJar := false
@@ -191,7 +190,7 @@ func (p *Myjar) SetCookies(u *url.URL, cookies []*http.Cookie) {
 
 // Cookies of client
 func (p *Myjar) Cookies(u *url.URL) []*http.Cookie {
-	fmt.Printf("The URL is : %s\n", u.String())
-	fmt.Printf("Cookie being returned is : %s\n", p.Jar[u.Host])
+	//fmt.Printf("The URL is : %s\n", u.String())
+	//fmt.Printf("Cookie being returned is : %s\n", p.Jar[u.Host])
 	return p.Jar[u.Host]
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -86,11 +86,26 @@ func GetMediaType(t string) string {
 	}
 }
 
-// GetH1 of html file
-func GetH1(htmlString *string) string {
+// GetH1s of html file
+// idx -1 = last h1 found
+// if index out of range set to last h1
+func GetH1(htmlString *string, idx int) string {
 	re := regexp.MustCompile(`[^>]*</h1>`)
 	h1s := re.FindAllString(*htmlString, -1)
-	return strings.TrimSuffix(GetLastItemString(h1s), "</h1>")
+
+	h1sLen := len(h1s)
+	if idx == -1 {
+		idx = h1sLen
+	}
+
+	// if index out of range set last
+	if h1sLen < idx+1 {
+		idx = h1sLen - 1
+		if idx == -1 {
+			return ""
+		}
+	}
+	return strings.TrimSuffix(h1s[idx], "</h1>")
 }
 
 // GetMeta of html file

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -182,21 +182,43 @@ func TestGetMediaType(t *testing.T) {
 
 func TestGetH1(t *testing.T) {
 	tests := []struct {
+		name       string
 		htmlString string
+		idx        int
 		want       string
 	}{
 		{
+			name:       "h1 tag with params",
 			htmlString: `<h1 class="entry-title" itemprop="name">Overflow 8</h1>`,
+			idx:        0,
 			want:       "Overflow 8",
 		},
 		{
+			name:       "normal case",
 			htmlString: `<h1>Overflow 8</h1>`,
+			idx:        0,
+			want:       "Overflow 8",
+		},
+		{
+			name:       "get specific",
+			htmlString: `<h1>Overflow 8</h1><h1>Overflow 9</h1><h1>Overflow 10</h1>`,
+			idx:        1,
+			want:       "Overflow 9",
+		}, {
+			name:       "out of range but has one, return it",
+			htmlString: `<h1>Overflow 8</h1>`,
+			idx:        1,
+			want:       "Overflow 8",
+		}, {
+			name:       "last",
+			htmlString: `<h1>Overflow 7</h1><h1>Overflow 8</h1>`,
+			idx:        -1,
 			want:       "Overflow 8",
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.htmlString, func(t *testing.T) {
-			h1 := GetH1(&tt.htmlString)
+		t.Run(tt.name, func(t *testing.T) {
+			h1 := GetH1(&tt.htmlString, tt.idx)
 
 			if h1 != tt.want {
 				t.Errorf("Got: %v - want: %v", h1, tt.want)


### PR DESCRIPTION
E-Hentai:
1. If gallery has more than 40 pages, then it will only download 40 (one page)
2. Now supports the -p parameter for some reason it was missing

ExHentai:
1. Also stopped after 40 pages
2. File extension contained 2 dots

Everything above should be fixed now.

Request:
- Removed logging from the CookieJar

All regexes are now using raw strings. Also refactored GetH1 and added it to e-hentai/exhentai.  
Removed hentaihaven.red wrongly matched "popular hentai" on the side bar